### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/borc",
-  "version": "2.1.0-exodus4",
+  "version": "2.1.1",
   "description": "Encode and parse data in the Concise Binary Object Representation (CBOR) data format (RFC7049).",
   "main": "./src/index.js",
   "repository": {


### PR DESCRIPTION
Bump version to avoid downgrade when the semver ^ is used.

https://exodusio.slack.com/archives/CP202D90Q/p1718308593643259